### PR TITLE
Review in the form of pull request

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -188,7 +188,12 @@ public class DataTierAllocationDecider extends AllocationDecider {
     }
 
     public static String[] parseTierList(String tiers) {
-        return Strings.tokenizeToStringArray(tiers, ",");
+        if (Strings.hasLength(tiers) == false) {
+            // avoid parsing overhead in the null/empty string case
+            return new String[0];
+        } else {
+            return Strings.tokenizeToStringArray(tiers, ",");
+        }
     }
 
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -207,7 +207,6 @@ public class DataTierAllocationDecider extends AllocationDecider {
 
     private static boolean allocationAllowed(String tierSetting, Set<DiscoveryNodeRole> roles) {
         String[] values = parseTierList(tierSetting);
-        Set<String> roleNames = null;
         if (values.length == 0) {
             return true;
         }
@@ -224,13 +223,11 @@ public class DataTierAllocationDecider extends AllocationDecider {
             }
             return false;
         } else {
+            Set<String> roleNames = new HashSet<>(roles.size());
+            for (DiscoveryNodeRole role : roles) {
+                roleNames.add(role.roleName());
+            }
             for (String value : values) {
-                if (roleNames == null) {
-                    roleNames = new HashSet<>(roles.size());
-                    for (DiscoveryNodeRole role : roles) {
-                        roleNames.add(role.roleName());
-                    }
-                }
                 if (roleNames.contains(value) == false) {
                     return false;
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -232,12 +232,7 @@ public class DataTierAllocationDecider extends AllocationDecider {
             for (DiscoveryNodeRole role : roles) {
                 roleNames.add(role.roleName());
             }
-            for (String value : values) {
-                if (roleNames.contains(value) == false) {
-                    return false;
-                }
-            }
+            return roleNames.containsAll(Arrays.asList(values));
         }
-        return true;
     }
 }


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/78075

👋 @original-brownbear.

re: 5adcf14: the set declaration and initialization looked a bit funky to me, this is my attempt to make that a little more readable.

re: dfebb2a: `Strings.tokenizeToStringArray` does a healthy number of allocations, but we can shortcut it in the null/empty String case -- I was originally tempted to add a separate early return from `allocationAllowed` that checked `Strings.hasLength(tierSetting)` directly, but I thought this would capture more or less the same shortcut while keeping the code pretty clear.

re: ea03188: If we're allocating a `HashSet`, we might as well go all the way and use `containsAll` -- what do you think?

This is very much "hmmmm, what do you think about this?" -- we can take all, some, or none of these commits.